### PR TITLE
Changing the master/slave terminology

### DIFF
--- a/clock/pyBusPirateLite/I2Chigh.py
+++ b/clock/pyBusPirateLite/I2Chigh.py
@@ -50,7 +50,7 @@ class I2Chigh(I2C):
 
 
     def command(self, i2caddr, cmd):
-        """ Writes one byte command to slave """
+        """ Writes one byte command to subordinate """
         self.send_start_bit();
         stat = self.bulk_trans(2, [i2caddr<<1, cmd]);
         self.send_stop_bit();

--- a/pyBusPirate/nrfErase.py
+++ b/pyBusPirate/nrfErase.py
@@ -1180,11 +1180,11 @@ ID Base address Peripheral Instance Description
 0 0x40000000 MPU MPU Memory Protection Unit
 1 0x40001000 RADIO RADIO 2.4 GHz radio
 2 0x40002000 UART UART0 Universal Asynchronous Receiver/Transmitter
-3 0x40003000 SPI SPI0 SPI master 0
-3 0x40003000 TWI TWI0 Two-wire interface master 0
-4 0x40004000 SPI SPI1 SPI master 1
-4 0x40004000 SPIS SPIS1 SPI slave 1
-4 0x40004000 TWI TWI1 Two-wire interface master 1
+3 0x40003000 SPI SPI0 SPI main 0
+3 0x40003000 TWI TWI0 Two-wire interface main 0
+4 0x40004000 SPI SPI1 SPI main 1
+4 0x40004000 SPIS SPIS1 SPI subordinate 1
+4 0x40004000 TWI TWI1 Two-wire interface main 1
 6 0x40006000 GPIOTE GPIOTE GPIO tasks and events
 7 0x40007000 ADC ADC Analog to digital converter
 8 0x40008000 TIMER TIMER0 Timer 0

--- a/pyBusPirate/pyBusPirateLite/I2Chigh.py
+++ b/pyBusPirate/pyBusPirateLite/I2Chigh.py
@@ -50,7 +50,7 @@ class I2Chigh(I2C):
 
 
     def command(self, i2caddr, cmd):
-        """ Writes one byte command to slave """
+        """ Writes one byte command to subordinate """
         self.send_start_bit();
         stat = self.bulk_trans(2, [i2caddr<<1, cmd]);
         self.send_stop_bit();


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.